### PR TITLE
[CI]Add release ci to deploy to pages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release
+
+on:
+  push:
+    branches: [ "master" ]
+    tags: [v0.*]
+  pull_request:
+    branches: [ "master" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy-web-demo:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    env:
+      RUSTFLAGS: --cfg=web_sys_unstable_apis
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install wasm-pack
+      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      
+    - name: caching
+      uses: Swatinem/rust-cache@v1
+      with:
+        key: wasm-pack-web-demo-b
+
+    - name: Build Wasm Pack
+      run: wasm-pack build mdanceio --out-dir ../target/pkg
+
+    - name: Use Node.js 16.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+        cache: 'npm'
+        cache-dependency-path: mdance-demo/package-lock.json
+
+    - name: Install Dependencies
+      working-directory: ./mdance-demo
+      run: npm install
+
+    - name: Build
+      working-directory: ./mdance-demo
+      run: npm run build
+    - name: Setup Pages
+      uses: actions/configure-pages@v2
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: mdance-demo/build/
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [ "master" ]
     tags: [v0.*]
-  pull_request:
-    branches: [ "master" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The new `Release` Action will build a wasm pack, then we use the package and build a web single-page application. We will deploy the web application to GitHub Pages. 