### PR TITLE
[mdanceio] Add WebGL Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,19 @@ jobs:
 
     - name: Build
       run: wasm-pack build mdanceio --out-dir ../target/pkg
+
+    - name: Build with WebGL support
+      run: wasm-pack build mdanceio --out-dir ../target/pkg-webgl --scope webgl-supports -- --features webgl
     
     - uses: actions/upload-artifact@v3
       with:
         name: npm-package
         path: target/pkg/
+    
+    - uses: actions/upload-artifact@v3
+      with:
+        name: npm-package-webgl
+        path: target/pkg-webgl/
   
   build-example:
     strategy: 
@@ -106,6 +114,9 @@ jobs:
 
     - name: Build Wasm Pack
       run: wasm-pack build mdanceio --out-dir ../target/pkg
+
+    - name: Build Wasm Pack with WebGL support
+      run: wasm-pack build mdanceio --out-dir ../target/pkg-webgl --scope webgl-supports -- --features webgl
 
     - name: Use Node.js 16.x
       uses: actions/setup-node@v3

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -35,15 +35,9 @@
             }
         },
         {
-            "label": "rust: cargo build-wasm",
-            "type": "cargo",
-            "command": "build",
-            "args": [
-                "--no-default-features",
-                "--target",
-                "wasm32-unknown-unknown",
-                "--lib"
-            ],
+            "label": "wasm: pack",
+            "type": "shell",
+            "command": "wasm-pack build mdanceio --out-dir ../target/pkg",
             "problemMatcher": [
                 "$rustc"
             ],
@@ -54,18 +48,9 @@
             }
         },
         {
-            "label": "wasm: bindgen",
+            "label": "wasm: pack-webgl",
             "type": "shell",
-            "command": "wasm-bindgen --out-dir target/wasm-bundle target/wasm32-unknown-unknown/debug/mdanceio.wasm",
-            "dependsOn": [
-                "rust: cargo build-wasm"
-            ],
-            "problemMatcher": []
-        },
-        {
-            "label": "wasm: pack",
-            "type": "shell",
-            "command": "wasm-pack build mdanceio --out-dir ../target/pkg",
+            "command": "wasm-pack build mdanceio --out-dir ../target/pkg-webgl --scope webgl-supports -- --features webgl",
             "problemMatcher": [
                 "$rustc"
             ],
@@ -126,7 +111,8 @@
             "path": "mdance-demo",
             "problemMatcher": [],
             "dependsOn": [
-                "wasm: pack"
+                "wasm: pack",
+                "wasm: pack-webgl"
             ],
             "detail": "react-app-rewired start"
         },
@@ -138,7 +124,8 @@
             "group": "build",
             "problemMatcher": [],
             "dependsOn": [
-                "wasm: pack"
+                "wasm: pack",
+                "wasm: pack-webgl"
             ],
             "detail": "react-app-rewired build"
         }

--- a/mdance-demo/package-lock.json
+++ b/mdance-demo/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^18.7.13",
         "@types/react": "^18.0.17",
         "@types/react-dom": "^18.0.6",
+        "@webgl-supports/mdanceio": "file:../target/pkg-webgl",
         "mdanceio": "file:../target/pkg",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -34,6 +35,10 @@
     },
     "../target/pkg": {
       "name": "mdanceio",
+      "version": "0.1.0",
+      "license": "MIT"
+    },
+    "../target/pkg-webgl": {
       "version": "0.1.0",
       "license": "MIT"
     },
@@ -4322,6 +4327,10 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@webgl-supports/mdanceio": {
+      "resolved": "../target/pkg-webgl",
+      "link": true
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -19349,6 +19358,9 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@webgl-supports/mdanceio": {
+      "version": "file:../target/pkg-webgl"
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",

--- a/mdance-demo/package.json
+++ b/mdance-demo/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
     "mdanceio": "file:../target/pkg",
+    "@webgl-supports/mdanceio": "file:../target/pkg-webgl",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/mdance-demo/src/App.tsx
+++ b/mdance-demo/src/App.tsx
@@ -114,13 +114,23 @@ function App() {
     };
   }, [playing, playUpdate]); // Make sure the effect runs only once
   useEffect(() => {
-    import('mdanceio').then(module => {
-      if (!clientPromise.current) {
-        console.log("Creating WasmClient...")
-        let backend = use_webgpu? module.Backend.WebGPU: module.Backend.WebGL;
-        clientPromise.current = module.WasmClient.new(graph_display_ref.current!, backend)
-      }
-    })
+    if (use_webgpu) {
+      import('mdanceio').then(module => {
+        if (!clientPromise.current) {
+          console.log("Creating WasmClient...")
+          console.log("MDanceIO prefers WebGPU as Backend")
+          clientPromise.current = module.WasmClient.new(graph_display_ref.current!)
+        }
+      })
+    } else {
+      import('@webgl-supports/mdanceio').then(module => {
+        if (!clientPromise.current) {
+          console.log("Creating WasmClient...")
+          console.log("MDanceIO prefers WebGL as Backend")
+          clientPromise.current = module.WasmClient.new(graph_display_ref.current!)
+        }
+      })
+    }
   }, [use_webgpu])
 
   return (
@@ -140,7 +150,9 @@ function App() {
         <div><span className="Hint">Texture Prefix</span> <input type="text" value={textureNamePrefix} onChange={(e) =>
           setTextureNamePrefix(e.target.value)
         }/></div>
-        <div className="Hint">We use the texture file name to match needed texture. If texture file is behind a directory, add the directory path as prefix when loading. </div>
+        <div className="Hint">We use the texture file name to match needed texture. If texture file is behind a
+          directory, add the directory path as prefix when loading.
+        </div>
         <button className="Load-Texture-Button" onClick={onLoadTextureClick}> Load Texture</button>
         <button className="Load-Motion-Button" onClick={onLoadMotionClick}> Load Motion</button>
         <button className="Play-Button" disabled={playing} onClick={onPlayClick}> Play</button>

--- a/mdance-demo/src/App.tsx
+++ b/mdance-demo/src/App.tsx
@@ -1,10 +1,15 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import './App.css';
 import {WasmClient} from 'mdanceio';
 import {readFile} from "./utils";
 
 function App() {
   const graph_display_ref = useRef<HTMLCanvasElement>(null);
+  const use_webgpu = useMemo(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    let param_webgpu = urlParams.get("webgpu");
+    return param_webgpu && param_webgpu.toLowerCase() !== "false" && param_webgpu !== "0"
+  }, []);
   const clientPromise = useRef<Promise<WasmClient>>();
   const modelFile = useRef<HTMLInputElement>(null)
   const onLoadModelClick = () => {
@@ -112,10 +117,11 @@ function App() {
     import('mdanceio').then(module => {
       if (!clientPromise.current) {
         console.log("Creating WasmClient...")
-        clientPromise.current = module.WasmClient.new(graph_display_ref.current!, module.Backend.WebGPU)
+        let backend = use_webgpu? module.Backend.WebGPU: module.Backend.WebGL;
+        clientPromise.current = module.WasmClient.new(graph_display_ref.current!, backend)
       }
     })
-  }, [])
+  }, [use_webgpu])
 
   return (
     <div className="App">

--- a/mdanceio/Cargo.toml
+++ b/mdanceio/Cargo.toml
@@ -17,8 +17,11 @@ path = "tests/root.rs"
 [[example]]
 name = "winit_app"
 
+[features]
+webgl = ["wgpu/webgl"]
+
 [dependencies]
-wgpu = { version = "0.14.0", features = ["trace", "webgl"] }
+wgpu = { version = "0.14.0", features = ["trace"] }
 log = "0.4"
 bytemuck = { version = "1.12.1", features = ["derive"] }
 cgmath = "0.18.0"

--- a/mdanceio/Cargo.toml
+++ b/mdanceio/Cargo.toml
@@ -18,7 +18,7 @@ path = "tests/root.rs"
 name = "winit_app"
 
 [dependencies]
-wgpu = { version = "0.14.0", features = ["trace"] }
+wgpu = { version = "0.14.0", features = ["trace", "webgl"] }
 log = "0.4"
 bytemuck = { version = "1.12.1", features = ["derive"] }
 cgmath = "0.18.0"

--- a/mdanceio/src/model.rs
+++ b/mdanceio/src/model.rs
@@ -16,7 +16,7 @@ use nanoem::{
 use crate::{
     bounding_box::BoundingBox,
     camera::{Camera, PerspectiveCamera},
-    deformer::Deformer,
+    deformer::{CommonDeformer, Deformer, WgpuDeformer},
     drawable::{DrawContext, DrawType, Drawable},
     error::MdanceioError,
     light::Light,
@@ -55,14 +55,14 @@ pub type SoftBodyIndex = usize;
 #[repr(C)]
 #[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct VertexUnit {
-    position: [f32; 4],
-    normal: [f32; 4],
-    texcoord: [f32; 4],
-    edge: [f32; 4],
-    uva: [[f32; 4]; 4],
-    weights: [f32; 4],
-    indices: [f32; 4],
-    info: [f32; 4], /* type,vertexIndex,edgeSize,padding */
+    pub position: [f32; 4],
+    pub normal: [f32; 4],
+    pub texcoord: [f32; 4],
+    pub edge: [f32; 4],
+    pub uva: [[f32; 4]; 4],
+    pub weights: [f32; 4],
+    pub indices: [f32; 4],
+    pub info: [f32; 4], /* type,vertexIndex,edgeSize,padding */
 }
 
 impl From<VertexSimd> for VertexUnit {
@@ -513,22 +513,22 @@ impl Model {
                 }
 
                 log::trace!("Len(vertices): {}", vertices.len());
-                let mut vertex_buffer_data: Vec<VertexUnit> = vec![];
-                for vertex in &vertices {
-                    vertex_buffer_data.push(vertex.simd.into());
-                }
-                log::trace!("Len(vertex_buffer): {}", vertex_buffer_data.len());
                 let edge_size =
                     Self::internal_edge_size(&bones, global_camera, edge_size_scale_factor);
-                let skin_deformer = Deformer::new(
-                    &vertex_buffer_data,
-                    &vertices,
-                    &bones,
-                    &shared_fallback_bone,
-                    &morphs,
-                    edge_size,
-                    device,
-                );
+
+                log::info!("{:?}", device.limits());
+                let skin_deformer = if device.limits().max_storage_buffers_per_shader_stage < 6 {
+                    Deformer::Software(CommonDeformer::new(&vertices))
+                } else {
+                    Deformer::Wgpu(Box::new(WgpuDeformer::new(
+                        &vertices,
+                        &bones,
+                        &shared_fallback_bone,
+                        &morphs,
+                        edge_size,
+                        device,
+                    )))
+                };
                 let bytes_per_vertex = std::mem::size_of::<VertexUnit>();
                 let unpadded_size = vertices.len() * bytes_per_vertex;
                 let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize;
@@ -536,13 +536,17 @@ impl Model {
                 let vertex_buffer_even = device.create_buffer(&wgpu::BufferDescriptor {
                     label: Some(format!("Model/{}/VertexBuffer/Even", canonical_name).as_str()),
                     size: (unpadded_size + padding) as u64,
-                    usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::STORAGE,
+                    usage: wgpu::BufferUsages::VERTEX
+                        | wgpu::BufferUsages::STORAGE
+                        | wgpu::BufferUsages::COPY_DST,
                     mapped_at_creation: false,
                 });
                 let vertex_buffer_odd = device.create_buffer(&wgpu::BufferDescriptor {
                     label: Some(format!("Model/{}/VertexBuffer/Odd", canonical_name).as_str()),
                     size: (unpadded_size + padding) as u64,
-                    usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::STORAGE,
+                    usage: wgpu::BufferUsages::VERTEX
+                        | wgpu::BufferUsages::STORAGE
+                        | wgpu::BufferUsages::COPY_DST,
                     mapped_at_creation: false,
                 });
                 let vertex_buffers = [vertex_buffer_even, vertex_buffer_odd];
@@ -556,7 +560,20 @@ impl Model {
                     },
                 );
                 let mut stage_vertex_buffer_index = 0;
-                skin_deformer.execute(&vertex_buffers[stage_vertex_buffer_index], device, queue);
+                match &skin_deformer {
+                    Deformer::Wgpu(deformer) => {
+                        deformer.execute(&vertex_buffers[stage_vertex_buffer_index], device, queue);
+                    }
+                    Deformer::Software(deformer) => deformer.execute(
+                        &vertices,
+                        &bones,
+                        &morphs,
+                        edge_size,
+                        &vertex_buffers[stage_vertex_buffer_index],
+                        device,
+                        queue,
+                    ),
+                }
                 stage_vertex_buffer_index = 1 - stage_vertex_buffer_index;
 
                 let mut camera = Box::new(PerspectiveCamera::new());
@@ -1850,12 +1867,23 @@ impl Model {
         queue: &wgpu::Queue,
     ) {
         if self.states.dirty_staging_buffer {
-            self.skin_deformer.update_buffer(self, camera, queue);
-            self.skin_deformer.execute(
-                &self.vertex_buffers[self.stage_vertex_buffer_index],
-                device,
-                queue,
-            );
+            match &self.skin_deformer {
+                Deformer::Wgpu(deformer) => {
+                    deformer.update_buffer(self, camera, queue);
+                    deformer.execute(
+                        &self.vertex_buffers[self.stage_vertex_buffer_index],
+                        device,
+                        queue,
+                    );
+                }
+                Deformer::Software(deformer) => deformer.execute_model(
+                    self,
+                    camera,
+                    &self.vertex_buffers[self.stage_vertex_buffer_index],
+                    device,
+                    queue,
+                ),
+            }
             self.stage_vertex_buffer_index = 1 - self.stage_vertex_buffer_index;
             self.states.dirty_morph = false;
             self.states.dirty_staging_buffer = false;
@@ -3052,6 +3080,7 @@ impl Constraint {
     }
 }
 
+// TODO: Optimize duplicated vertex structure
 #[derive(Debug, Clone, Copy)]
 pub struct VertexSimd {
     // may use simd128

--- a/mdanceio/src/resources/shaders/model_color.wgsl
+++ b/mdanceio/src/resources/shaders/model_color.wgsl
@@ -1,15 +1,3 @@
-fn saturate(x: f32) -> f32 {
-  return clamp(x, 0.0, 1.0);
-}
-
-fn saturate_v2(x: vec2<f32>) -> vec2<f32> {
-    return clamp(x, vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 1.0));
-}
-
-fn saturate_v4(x: vec4<f32>) -> vec4<f32> {
-    return clamp(x, vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0));
-}
-
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) normal: vec3<f32>,
@@ -150,7 +138,7 @@ fn vs_main(
     vout.eye = model_parameters.camera_position.xyz - (model_parameters.model_matrix * position).xyz;
     vout.texcoord0 = vin.texcoord0;
     vout.texcoord1 = sphere;
-    vout.color0 = saturate_v4(vec4<f32>(color, model_parameters.material_diffuse.a));
+    vout.color0 = saturate(vec4<f32>(color, model_parameters.material_diffuse.a));
     vout.shadow0 = model_parameters.light_view_projection_matrix * position;
     // TODO: when NANOEM_IO_HAS_POINT
     return vout;
@@ -185,7 +173,7 @@ fn fs_main(
     let light_position = -model_parameters.light_direction.xyz;
     if (has_shadow_map_texture()) {
         let texcoord0 = fin.shadow0 / fin.shadow0.w;
-        let satu_texc = saturate_v2(texcoord0.xy);
+        let satu_texc = saturate(texcoord0.xy);
         let toon_color = textureSample(toon_texture, toon_texture_sampler, vec2<f32>(0.0, 1.0));
         var coverage = shadow_coverage(texcoord0, model_parameters.shadow_map_size);
         if (satu_texc.x == texcoord0.x && satu_texc.y == texcoord0.y) {
@@ -211,5 +199,5 @@ fn fs_main(
         let spec = pow(specular_angle, specular_power);
         material_color = vec4<f32>(material_color.rgb + model_parameters.material_specular.rgb * model_parameters.light_color.rgb * spec, material_color.a);
     }
-    return saturate_v4(material_color);
+    return saturate(material_color);
 }

--- a/mdanceio/src/resources/shaders/model_edge.wgsl
+++ b/mdanceio/src/resources/shaders/model_edge.wgsl
@@ -1,15 +1,3 @@
-fn saturate(x: f32) -> f32 {
-    return clamp(x, 0.0, 1.0);
-}
-
-fn saturate_v2(x: vec2<f32>) -> vec2<f32> {
-    return clamp(x, vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 1.0));
-}
-
-fn saturate_v4(x: vec4<f32>) -> vec4<f32> {
-    return clamp(x, vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0));
-}
-
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) normal: vec3<f32>,

--- a/mdanceio/src/resources/shaders/model_ground_shadow.wgsl
+++ b/mdanceio/src/resources/shaders/model_ground_shadow.wgsl
@@ -1,15 +1,3 @@
-fn saturate(x: f32) -> f32 {
-    return clamp(x, 0.0, 1.0);
-}
-
-fn saturate_v2(x: vec2<f32>) -> vec2<f32> {
-    return clamp(x, vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 1.0));
-}
-
-fn saturate_v4(x: vec4<f32>) -> vec4<f32> {
-    return clamp(x, vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0));
-}
-
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) normal: vec3<f32>,

--- a/mdanceio/src/resources/shaders/model_zplot.wgsl
+++ b/mdanceio/src/resources/shaders/model_zplot.wgsl
@@ -1,15 +1,3 @@
-fn saturate(x: f32) -> f32 {
-  return clamp(x, 0.0, 1.0);
-}
-
-fn saturate_v2(x: vec2<f32>) -> vec2<f32> {
-    return clamp(x, vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 1.0));
-}
-
-fn saturate_v4(x: vec4<f32>) -> vec4<f32> {
-    return clamp(x, vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0));
-}
-
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) normal: vec3<f32>,

--- a/mdanceio/src/wasm_proxy.rs
+++ b/mdanceio/src/wasm_proxy.rs
@@ -21,7 +21,7 @@ impl<T> CanvasSize<T> {
 pub enum Backend {
     All,
     WebGPU,
-    // WebGL,
+    WebGL,
 }
 
 #[wasm_bindgen]
@@ -50,6 +50,7 @@ impl WasmClient {
         let backends = match backend {
             Backend::All => wgpu::util::backend_bits_from_env().unwrap_or(wgpu::Backends::all()),
             Backend::WebGPU => wgpu::Backends::BROWSER_WEBGPU,
+            Backend::WebGL => wgpu::Backends::GL,
         };
 
         let instance = wgpu::Instance::new(backends);

--- a/mdanceio/src/wasm_proxy.rs
+++ b/mdanceio/src/wasm_proxy.rs
@@ -18,13 +18,6 @@ impl<T> CanvasSize<T> {
 }
 
 #[wasm_bindgen]
-pub enum Backend {
-    All,
-    WebGPU,
-    WebGL,
-}
-
-#[wasm_bindgen]
 pub struct WasmClient {
     instance: wgpu::Instance,
     surface: wgpu::Surface,
@@ -40,18 +33,14 @@ pub struct WasmClient {
 /// 我希望通过WasmClient为JS层调用提供接口。JS层应自行处理渲染请求频率，通知视口resize，点击，拖动等事件，并处理好可能有的回调。
 #[wasm_bindgen]
 impl WasmClient {
-    pub fn new(canvas: &web_sys::HtmlCanvasElement, backend: Backend) -> js_sys::Promise {
+    pub fn new(canvas: &web_sys::HtmlCanvasElement) -> js_sys::Promise {
         let level: log::Level = log::Level::Trace;
         console_log::init_with_level(level).expect("could not initialize logger");
         std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 
         log::info!("Initializing the surface...");
 
-        let backends = match backend {
-            Backend::All => wgpu::util::backend_bits_from_env().unwrap_or(wgpu::Backends::all()),
-            Backend::WebGPU => wgpu::Backends::BROWSER_WEBGPU,
-            Backend::WebGL => wgpu::Backends::GL,
-        };
+        let backends = wgpu::util::backend_bits_from_env().unwrap_or(wgpu::Backends::all());
 
         let instance = wgpu::Instance::new(backends);
         let size = CanvasSize::new(canvas.width(), canvas.height());


### PR DESCRIPTION
1. Add software skin deformer support
    - Change `Deformer` to enum
    - Add enum members `WgpuDeformer` and `SoftwareDeformer`
2. Add WebGL Support
    - Add feature `webgl` to support WebGL backend
    - Update React Demo where users could enable WebGPU using path parameters
    - Add new NPM package `@webgl-supports/mdanceio`
    - Remove parameter `backend` in `WasmProxy` constructor
3. Fix `saturate` conflict with standard in wgsl